### PR TITLE
Adds a proper field name so server would recognize data

### DIFF
--- a/src/kraken-net-v2/Http/Connection.cs
+++ b/src/kraken-net-v2/Http/Connection.cs
@@ -110,7 +110,7 @@ namespace Kraken.Http
                     new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture)))
             {
                 var json = JsonConvert.SerializeObject(apiRequest.Body, _serializerSettings);
-                content.Add(new StringContent(json, Encoding.UTF8, "application/json"));
+                content.Add(new StringContent(json, Encoding.UTF8, "application/json"), "data");
 
                 content.Add(new StreamContent(new MemoryStream(image)), filename, filename);
 

--- a/src/kraken-net/Http/Connection.cs
+++ b/src/kraken-net/Http/Connection.cs
@@ -110,7 +110,7 @@ namespace Kraken.Http
                     new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture)))
             {
                 var json = JsonConvert.SerializeObject(apiRequest.Body, _serializerSettings);
-                content.Add(new StringContent(json, Encoding.UTF8, "application/json"));
+                content.Add(new StringContent(json, Encoding.UTF8, "application/json"), "data");
 
                 content.Add(new StreamContent(new MemoryStream(image)), filename, filename);
 


### PR DESCRIPTION
## Description
Currently the optimize functionality is broken, because the api server requires passing credentials and other parameters in a ["data" field](https://kraken.io/docs/upload-url). This change sets the field name, which fixes the issue.

## Steps to Test or Reproduce

Checked upload with the old and with the new logic.

The client code I've used:

```
using System;
using System.Net;
using Kraken;
using Kraken.Http;
using Kraken.Model;

namespace kraken_net_cli
{
    class Program
    {
        static void Main(string[] args)
        {
            var connection = Connection.Create("your_key", "your_secret");
            var client = new Client(connection);
            var UploadResponse = client.OptimizeWait("./example.jpg",
                new OptimizeUploadWaitRequest()
                {
                    Lossy = true,
                });

            UploadResponse.Wait();

            Console.WriteLine(UploadResponse.Result.Body);
            if (UploadResponse.Result.StatusCode == HttpStatusCode.OK)
            {
                Console.WriteLine(UploadResponse.Result.Body.KrakedUrl);
            }
            else
            {
                Console.WriteLine("That went wrong.");
            }

        }
    }
}

```

## Todos
- [ ] Tests succeeded
- [ ] Documentation updated
- [ ] Nuget release information & Build version updated (build.fsx)